### PR TITLE
Add content links to email footer

### DIFF
--- a/stocks.Rmd
+++ b/stocks.Rmd
@@ -143,9 +143,9 @@ if (abs(diff) > params$threshold || params$force) {
 
     Team Lead",
     footer = "
-    This <strong>{report_name}</strong> document is available on our RStudio Connect server <code>[here]({report_url})</code>.
+    This <strong>{report_name}</strong> document is available on our RStudio Connect server [here]({report_url}).
 
-    To stop receiving these emails, <code>[unsubscribe]({subscription_url})</code>.
+    To stop receiving these emails, [unsubscribe]({subscription_url}).
     "
   )
   rmarkdown::output_metadata$set(rsc_email_body_html = msg$html_str)

--- a/stocks.Rmd
+++ b/stocks.Rmd
@@ -144,7 +144,7 @@ if (abs(diff) > params$threshold || params$force) {
     Team Lead",
     footer = "
     This <strong>{report_name}</strong> document 
-    is available on our connect server <code>[here]({report_url})</code>
+    is available on our RStudio Connect server <code>[here]({report_url})</code>
 
     To stop receiving these emails, <code>[unsubscribe]({subscription_url})</code>
     "

--- a/stocks.Rmd
+++ b/stocks.Rmd
@@ -141,7 +141,12 @@ if (abs(diff) > params$threshold || params$force) {
     Best,
     
 
-    Team Lead"
+    Team Lead",
+    footer = "
+    This {report_name} document is available at {report_url}
+
+    To stop receiving these emails, unsubscribe here: {subscription_url}
+    "
   )
   rmarkdown::output_metadata$set(rsc_email_body_html = msg$html_str)
   rmarkdown::output_metadata$set(rsc_email_images = msg$images)

--- a/stocks.Rmd
+++ b/stocks.Rmd
@@ -143,10 +143,9 @@ if (abs(diff) > params$threshold || params$force) {
 
     Team Lead",
     footer = "
-    This <strong>{report_name}</strong> document 
-    is available on our RStudio Connect server <code>[here]({report_url})</code>
+    This <strong>{report_name}</strong> document is available on our RStudio Connect server <code>[here]({report_url})</code>.
 
-    To stop receiving these emails, <code>[unsubscribe]({subscription_url})</code>
+    To stop receiving these emails, <code>[unsubscribe]({subscription_url})</code>.
     "
   )
   rmarkdown::output_metadata$set(rsc_email_body_html = msg$html_str)

--- a/stocks.Rmd
+++ b/stocks.Rmd
@@ -143,9 +143,10 @@ if (abs(diff) > params$threshold || params$force) {
 
     Team Lead",
     footer = "
-    This {report_name} document is available at {report_url}
+    This <strong>{report_name}</strong> document 
+    is available on our connect server <code>[here]({report_url})</code>
 
-    To stop receiving these emails, unsubscribe here: {subscription_url}
+    To stop receiving these emails, <code>[unsubscribe]({subscription_url})</code>
     "
   )
   rmarkdown::output_metadata$set(rsc_email_body_html = msg$html_str)

--- a/stocks.Rmd
+++ b/stocks.Rmd
@@ -21,6 +21,10 @@ library(formattable)
 library(ggplot2)
 library(ggthemes)
 
+report_name <- Sys.getenv("RSC_REPORT_NAME")
+report_url <- Sys.getenv("RSC_REPORT_URL")
+subscription_url <- Sys.getenv("RSC_REPORT_SUBSCRIPTION_URL")
+
 prices <- round(getSymbols(params$symbol, auto.assign = FALSE, src = 'yahoo'), 2)
 close <- Cl(last(prices))
 open <- Op(last(prices))


### PR DESCRIPTION
1.6.7 Feature Demo - Creates a footer with links to the report URL and subscription management URL